### PR TITLE
2-apis-for-board-locations

### DIFF
--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -75,6 +75,21 @@ def get_logbook(board, token, user_id, types="ascent"):
 
 
 def get_gyms(board):
+    """
+    :return:
+        {
+            "gyms": [
+                {
+                    'id': 373656,
+                    'username': '<username>',
+                    'name': '<name>',
+                    'latitude': 48.10135,
+                    'longitude': 11.30113
+                },
+                ...
+            ]
+        }
+    """
     response = requests.get(f"{API_HOSTS[board]}/v1/pins?types=gym")
     response.raise_for_status()
     return response.json()
@@ -191,4 +206,13 @@ def logbook_entries(board, username, password, grade_type="font"):
                 else boardlib.util.grades.FONT_TO_HUECO[font_grade]
             ),
             "tries": attempt_id if attempt_id else raw_entry["bid_count"],
+        }
+
+
+def gym_boards(board):
+    for gym in get_gyms(board)["gyms"]:
+        yield {
+            "name": gym["name"],
+            "latitude": gym["latitude"],
+            "longitude": gym["longitude"],
         }

--- a/src/boardlib/api/moon.py
+++ b/src/boardlib/api/moon.py
@@ -159,3 +159,35 @@ def logbook_entries(board, username, password, grade_type="font"):
             ),
             "tries": ATTEMPTS_TO_COUNT[entry["NumberOfTries"]],
         }
+
+
+def get_map_markers(session):
+    """
+    :return: list of board objects. For example:
+        {
+            "Name": "The School Room",
+            "Description": "The original MoonBoard in the legendary School Room. \r\n\r\nThe School Room, Sheffield is a high spec members-only training facility for intermediate to advanced climbers aged 18+ who wish to improve their strength and endurance for climbing. \r\n\r\nOpen 24/7, 7-days a week.",
+            "Image": "/Content/Account/Users/MoonBoards/SchoolRoom.jpg",
+            "Latitude": 53.386304,
+            "Longitude": -1.47619,
+            "IsCommercial": true,
+            "IsLed": true,
+            "LatLng": [53.386304, -1.47619]
+        }
+    """
+    response = session.get(
+        f"{HOST}/MoonBoard/GetMapMarkers",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def gym_boards(session):
+    for marker in get_map_markers(session):
+        if marker["IsCommercial"]:
+            yield {
+                "name": marker["Name"],
+                "latitude": marker["Latitude"],
+                "longitude": marker["Longitude"],
+            }

--- a/tests/boardlib/api/test_aurora.py
+++ b/tests/boardlib/api/test_aurora.py
@@ -178,6 +178,25 @@ class TestAurora(unittest.TestCase):
             },
         )
 
+    @unittest.mock.patch(
+        "boardlib.api.aurora.get_gyms",
+        side_effect=lambda *args, **kwargs: {
+                "gyms": [
+                    {'id': 1575, 'username': 'testuser', 'name': 'testgym', 'latitude': 51.43236, 'longitude': 6.7432}
+                ]
+            
+        },
+    )
+    def test_gym_boards(self, mock_get_gyms):
+        self.assertEqual(
+            next(boardlib.api.aurora.gym_boards("aurora")),
+            {
+                "name": "testgym",
+                "latitude": 51.43236,
+                "longitude": 6.7432,
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/boardlib/api/test_moon.py
+++ b/tests/boardlib/api/test_moon.py
@@ -205,3 +205,47 @@ class TestMoon(unittest.TestCase):
                 "tries": "1",
             },
         )
+
+    def test_get_map_markers(self):
+        mock_session = MockSession(
+            MockResponse(
+                json_data="test",
+            )
+        )
+        self.assertEqual(
+            boardlib.api.moon.get_map_markers(mock_session),
+            "test",
+        )
+
+    def test_get_map_markers_failure(self):
+        mock_session = MockSession(
+            MockResponse(status_code=requests.codes.bad_request),
+        )
+        with self.assertRaises(requests.exceptions.HTTPError):
+            boardlib.api.moon.get_map_markers(mock_session)
+
+    def test_gym_boards(self):
+        mock_session = MockSession(
+            MockResponse(
+                json_data=[
+                    {
+                        "Name": "The School Room",
+                        "Description": "The original MoonBoard in the legendary School Room. \r\n\r\nThe School Room, Sheffield is a high spec members-only training facility for intermediate to advanced climbers aged 18+ who wish to improve their strength and endurance for climbing. \r\n\r\nOpen 24/7, 7-days a week.",
+                        "Image": "/Content/Account/Users/MoonBoards/SchoolRoom.jpg",
+                        "Latitude": 53.386304,
+                        "Longitude": -1.47619,
+                        "IsCommercial": True,
+                        "IsLed": True,
+                        "LatLng": [53.386304, -1.47619],
+                    }
+                ]
+            )
+        )
+        self.assertEqual(
+            next(boardlib.api.moon.gym_boards(mock_session)),
+            {
+                "name": "The School Room",
+                "latitude": 53.386304,
+                "longitude": -1.47619,
+            },
+        )


### PR DESCRIPTION
Creates an API for getting the commercial gym locations for boards. Unfortunately, a login seems to be needed for Moon but is not necessary for Aurora-based apps. The only common information between the the two APIs was name, lat, and long, so that is the only information I'm providing in the APIs. Another nuance is that the Moonboard does not say which type of board (2016/17/19 and angle) is at each location, though it sometimes says in the description.