### PR TITLE
New Full Logbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,28 @@ All [Aurora Climbing](https://auroraclimbing.com/) based boards (Kilter, Tension
 
 To download your logbook entries for a given board:
 
-`boardlib logbook <board_name> --username=<username> --output=<output_file_name>.csv --grade-type="hueco"`
+`boardlib logbook <board_name> --username=<username> --output=<output_file_name>.csv --grade-type="hueco" --database=<local_database_file>`
 
 This outputs a CSV file with the following fields:
 
 ```json
-["board", "angle", "name", "date", "grade", "tries", "is_mirror"]
+["board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "difficulty", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment"]
 ```
 
 For example, the command
 
-`boardlib moon2017 --username="Luke EF" --output="moon2017.csv" --grade-type="hueco"`
+`boardlib tension --username="Luke EF" --output="tension.csv" --grade-type="hueco" --database="tension.db"`
 
-would output a file named `moon2017.csv` with the following contents:
+would output a file named `tension.csv` with the following contents:
 
 ```
-board,angle,name,date,grade,tries, is_mirror
-moon2017,40,C3PO,2021-07-13,V5,1, False
-moon2017,40,LITTLE BLACK SUBMARINE,2021-07-13,V5,2, False
-moon2017,40,MOUNTAIN GOAT HARD,2021-07-13,V5,1, False
+board,angle,climb_name,date,logged_grade,displayed_grade,difficulty,tries,is_mirror,sessions_count,tries_total,is_repeat,is_ascent,comment
+tension,40,trash bag better,2024-06-17 16:21:23,V3,V3,16.0,3,False,1,3,False,True,
+tension,40,Bumble,2024-06-17 16:28:23,V3,V3,16.0,1,True,1,1,False,True,
+tension,40,sender2,2024-06-17 16:38:06,V5,V5,20.0,2,False,1,2,False,True,
 ...
 ```
-
+When no local database is provided, displayed_grade and difficulty remain empty.
 See `boardlib --help` for a full list of supported board names and feature flags.
 
 #### Supported Boards 🛹

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["bs4", "requests"]
+dependencies = ["bs4", "requests", "pandas"]
 
 [project.scripts]
 boardlib = "boardlib.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+pandas

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -10,8 +10,7 @@ import boardlib.api.moon
 import boardlib.db.aurora
 
 
-LOGBOOK_FIELDS = ("board", "angle", "name", "date", "grade", "tries", "is_mirror")
-FULL_LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", 'difficulty', "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
+LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "difficulty", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
 
 
 def logbook_entries(board, username, password, grade_type="font", database=None):
@@ -37,21 +36,6 @@ def write_entries(output_file, entries, no_headers=False, fields=LOGBOOK_FIELDS)
     writer.writerows(entries)
 
 
-def handle_logbook_command(args):
-    env_var = f"{args.board.upper()}_PASSWORD"
-    password = os.environ.get(env_var)
-    if not password:
-        password = getpass.getpass("Password: ")
-    entries = logbook_entries(args.board, args.username, password, args.grade_type, args.database)
-
-    if args.output:
-        with open(args.output, "w", encoding="utf-8") as output_file:
-            write_entries(output_file, entries, args.no_headers)
-    else:
-        sys.stdout.reconfigure(encoding="utf-8")
-        write_entries(sys.stdout, entries, args.no_headers)
-
-
 def handle_database_command(args):
     if not args.database_path.exists():
         args.database_path.parent.mkdir(parents=True, exist_ok=True)
@@ -64,19 +48,19 @@ def handle_database_command(args):
         print(f"Synchronized {row_count} rows in {table_name}")
 
 
-def handle_full_logbook_command(args):
+def handle_logbook_command(args):
     env_var = f"{args.board.upper()}_PASSWORD"
     password = os.environ.get(env_var)
     if not password:
         password = getpass.getpass("Password: ")
-    entries = boardlib.api.aurora.get_full_logbook_entries(args.board, args.username, password, args.grade_type, args.database)
+    entries = boardlib.api.aurora.logbook_entries(args.board, args.username, password, args.grade_type, args.database)
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as output_file:
-            write_entries(output_file, entries.to_dict(orient="records"), args.no_headers, fields=FULL_LOGBOOK_FIELDS)
+            write_entries(output_file, entries.to_dict(orient="records"), args.no_headers, fields=LOGBOOK_FIELDS)
     else:
         sys.stdout.reconfigure(encoding="utf-8")
-        write_entries(sys.stdout, entries.to_dict(orient="records"), args.no_headers, fields=FULL_LOGBOOK_FIELDS)
+        write_entries(sys.stdout, entries.to_dict(orient="records"), args.no_headers, fields=LOGBOOK_FIELDS)
 
 
 def add_database_parser(subparsers):
@@ -99,10 +83,10 @@ def add_database_parser(subparsers):
     )
     database_parser.set_defaults(func=handle_database_command)
 
-
+    
 def add_logbook_parser(subparsers):
     logbook_parser = subparsers.add_parser(
-        "logbook", help="Download logbook entries to CSV"
+        "logbook", help="Download full logbook entries (ascents and bids) to CSV"
     )
     logbook_parser.add_argument(
         "board",
@@ -127,52 +111,17 @@ def add_logbook_parser(subparsers):
     logbook_parser.add_argument(
         "-d",
         "--database",
-        help="Path to the local database (optional). Using a local database can significantly speed up the logbook generation. Create a local database with the 'boardlib database' command.",
+        help="Path to the local database (optional). Using a local database will significantly speed up the logbook generation and is required to retrieve 'displayed_grade' and 'difficulty'. Create a local database with the 'database' command.",
         type=pathlib.Path,
         required=False,
     )
     logbook_parser.set_defaults(func=handle_logbook_command)
-
-    
-def add_full_logbook_parser(subparsers):
-    full_logbook_parser = subparsers.add_parser(
-        "full_logbook", help="Download full logbook entries (ascents and bids) to CSV"
-    )
-    full_logbook_parser.add_argument(
-        "board",
-        help="Board name",
-        choices=sorted(
-            boardlib.api.moon.BOARD_IDS.keys() | boardlib.api.aurora.HOST_BASES.keys()
-        ),
-    )
-    full_logbook_parser.add_argument("-u", "--username", help="Username", required=True)
-    full_logbook_parser.add_argument("-o", "--output", help="Output file", required=False)
-    full_logbook_parser.add_argument(
-        "--no-headers", help="Don't write headers", action="store_true", required=False
-    )
-    full_logbook_parser.add_argument(
-        "-g",
-        "--grade-type",
-        help="Grade type",
-        choices=("font", "hueco"),
-        default="font",
-        required=False,
-    )
-    full_logbook_parser.add_argument(
-        "-d",
-        "--database",
-        help="Path to the local database (optional). Using a local database will significantly speed up the logbook generation and is required to retrieve 'displayed_grade'. Create a local database with the 'database' command.",
-        type=pathlib.Path,
-        required=False,
-    )
-    full_logbook_parser.set_defaults(func=handle_full_logbook_command)
     
 
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     add_logbook_parser(subparsers)
-    add_full_logbook_parser(subparsers)  # Add this line
     add_database_parser(subparsers)
     args = parser.parse_args()
     args.func(args)

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -11,7 +11,7 @@ import boardlib.db.aurora
 
 
 LOGBOOK_FIELDS = ("board", "angle", "name", "date", "grade", "tries", "is_mirror")
-FULL_LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent")
+FULL_LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
 
 
 def logbook_entries(board, username, password, grade_type="font", database=None):
@@ -161,7 +161,7 @@ def add_full_logbook_parser(subparsers):
     full_logbook_parser.add_argument(
         "-d",
         "--database",
-        help="Path to the local database (optional). Using a local database can significantly speed up the logbook generation. Create a local database with the 'boardlib database' command.",
+        help="Path to the local database (optional). Using a local database will significantly speed up the logbook generation and is required to retrieve 'displayed_grade'. Create a local database with the 'database' command.",
         type=pathlib.Path,
         required=False,
     )

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -11,7 +11,7 @@ import boardlib.db.aurora
 
 
 LOGBOOK_FIELDS = ("board", "angle", "name", "date", "grade", "tries", "is_mirror")
-FULL_LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
+FULL_LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", 'difficulty', "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
 
 
 def logbook_entries(board, username, password, grade_type="font", database=None):

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -391,3 +391,50 @@ def save_climb(
     )
     response.raise_for_status()
     return response.json()
+
+
+def get_bids_logbook(board, token, user_id):
+    sync_results = user_sync(board, token, user_id, tables=["bids"])
+    return sync_results["PUT"]["bids"]
+
+
+def bids_logbook_entries(board, username, password, db_path=None):
+    login_info = login(board, username, password)
+    raw_entries = get_bids_logbook(board, login_info["token"], login_info["user_id"])
+    
+    for raw_entry in raw_entries:
+        yield {
+            "uuid": raw_entry["uuid"],
+            "user_id": raw_entry["user_id"],
+            "climb_uuid": raw_entry["climb_uuid"],
+            "angle": raw_entry["angle"],
+            "is_mirror": raw_entry["is_mirror"],
+            "bid_count": raw_entry["bid_count"],
+            "comment": raw_entry["comment"],
+            "climbed_at": raw_entry["climbed_at"],
+            "created_at": raw_entry["created_at"],
+        }
+
+
+def bids_logbook_entries(board, username, password, db_path=None):
+    login_info = login(board, username, password)
+    raw_entries = get_bids_logbook(board, login_info["token"], login_info["user_id"])
+    
+    for raw_entry in raw_entries:
+        if db_path:
+            climb_name = get_climb_name_from_db(db_path, raw_entry["climb_uuid"])
+        else:
+            climb_name = get_climb_name(board, raw_entry["climb_uuid"])
+        
+        yield {
+            "uuid": raw_entry["uuid"],
+            "user_id": raw_entry["user_id"],
+            "climb_uuid": raw_entry["climb_uuid"],
+            "climb_name": climb_name if climb_name else "Unknown Climb",
+            "angle": raw_entry["angle"],
+            "is_mirror": raw_entry["is_mirror"],
+            "bid_count": raw_entry["bid_count"],
+            "comment": raw_entry["comment"],
+            "climbed_at": raw_entry["climbed_at"],
+            "created_at": raw_entry["created_at"],
+        }

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -407,7 +407,7 @@ def get_difficulty_from_db(database, climb_uuid, angle):
 
 
 def convert_difficulty_to_grade(difficulty, grades_dict, grade_type):
-    grade_info = grades_dict.get(round(difficulty), {})
+    grade_info = grades_dict.get(round(difficulty) if difficulty is not None else None, {})
     return grade_info.get("french_name" if grade_type == "font" else "verm_name")
 
 

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -542,3 +542,11 @@ def total_logbook_entries(board, username, password, grade_type="font", db_path=
     final_logbook_df['sessions_count'] = final_logbook_df.groupby(['climb_name', 'is_mirror'])['date'].rank(method='dense').astype(int)
     
     return final_logbook_df
+
+'''
+ToDo:
+* Consider Angle in Session_Count and is_repeat.
+* Get Grade from grade_stats
+    Either average_grade or displayed grade.
+    Solution for local db and API calls needed
+'''

--- a/tests/boardlib/api/test_aurora.py
+++ b/tests/boardlib/api/test_aurora.py
@@ -41,14 +41,14 @@ class TestAurora(unittest.TestCase):
             boardlib.api.aurora.explore("aurora", "test")
 
     @unittest.mock.patch(
-        "requests.get",
-        side_effect=get_mock_request(json_data={"logbook": []}),
+        "requests.post",
+        side_effect=get_mock_request(json_data={"PUT": {"ascents": []}}),
     )
-    def test_get_logbook(self, mock_get):
+    def test_get_logbook(self, mock_post):
         self.assertEqual(boardlib.api.aurora.get_logbook("aurora", "test", "test"), [])
 
     @unittest.mock.patch(
-        "requests.get",
+        "requests.post",
         side_effect=get_mock_request(status_code=requests.codes.bad_request),
     )
     def test_get_logbook_failure(self, mock_get):
@@ -128,7 +128,7 @@ class TestAurora(unittest.TestCase):
     )
     def test_sync(self, mock_get):
         self.assertEqual(
-            boardlib.api.aurora.sync("aurora", "test", "test"), "test_sync"
+            boardlib.api.aurora.user_sync("aurora", "test", "test"), "test_sync"
         )
 
     @unittest.mock.patch(
@@ -137,7 +137,7 @@ class TestAurora(unittest.TestCase):
     )
     def test_sync_failure(self, mock_get):
         with self.assertRaises(requests.exceptions.HTTPError):
-            boardlib.api.aurora.sync("aurora", "test", "test")
+            boardlib.api.aurora.user_sync("aurora", "test", "test")
 
     @unittest.mock.patch(
         "boardlib.api.aurora.login",
@@ -158,6 +158,9 @@ class TestAurora(unittest.TestCase):
                 "attempt_id": 0,
                 "bid_count": 5,
                 "angle": 30,
+                "is_listed": True,  
+                "is_mirror": False,
+                "comment": "Test comment",
             }
         ],
     )
@@ -173,8 +176,9 @@ class TestAurora(unittest.TestCase):
                 "angle": 30,
                 "name": "test_climb_name",
                 "date": "2021-09-30",
-                "grade": "5C",
+                "grade": "6a",
                 "tries": 5,
+                "is_mirror": False,
             },
         )
 

--- a/tests/boardlib/api/test_aurora.py
+++ b/tests/boardlib/api/test_aurora.py
@@ -139,48 +139,6 @@ class TestAurora(unittest.TestCase):
         with self.assertRaises(requests.exceptions.HTTPError):
             boardlib.api.aurora.user_sync("aurora", "test", "test")
 
-    @unittest.mock.patch(
-        "boardlib.api.aurora.login",
-        side_effect=lambda *args, **kwargs: {
-            "token": "test_token",
-            "user_id": "test_user_id",
-        },
-    )
-    @unittest.mock.patch(
-        "boardlib.api.aurora.get_logbook",
-        side_effect=lambda *args, **kwargs: [
-            {
-                "climb_uuid": "test_climb_id",
-                "climbed_at": "2021-09-30 20:31:48",
-                "grade": "test_grade",
-                "tries": "test_tries",
-                "difficulty": 15,
-                "attempt_id": 0,
-                "bid_count": 5,
-                "angle": 30,
-                "is_listed": True,  
-                "is_mirror": False,
-                "comment": "Test comment",
-            }
-        ],
-    )
-    @unittest.mock.patch(
-        "boardlib.api.aurora.get_climb_name",
-        side_effect=lambda *args, **kwargs: "test_climb_name",
-    )
-    def test_logbook_entries(self, mock_login, mock_get_climb_name, mock_get_logbook):
-        self.assertEqual(
-            next(boardlib.api.aurora.logbook_entries("aurora", "test", "test")),
-            {
-                "board": "aurora",
-                "angle": 30,
-                "name": "test_climb_name",
-                "date": "2021-09-30",
-                "grade": "6a",
-                "tries": 5,
-                "is_mirror": False,
-            },
-        )
 
     @unittest.mock.patch(
         "boardlib.api.aurora.get_gyms",


### PR DESCRIPTION
### Summary

I have created a feature to extract a more exhaustive logbook for Aurora boards. You can now retrieve a CSV file that includes attempts on boulders that haven't been climbed yet.

### New Logbook Fields

- **tries:** Returns the tries in the session.
- **tries_total:** Returns all tries on the same boulder (also taking angle and is_mirror into account).
- **sessions_count:** Returns the number of sessions on the boulder.
- **logged_grade:** Returns the grade that has been logged by the user.
- **displayed_grade:** Returns the grade provided by the app (integrated because the difficulty is only logged when a climb has been completed successfully).
- **is_ascent:** Indicates whether the boulder was climbed in this session.

These features represent the information I’d like to use for my own analysis, but I believe they might be useful for others as well.
### Problems/Issues/Questions
- **displayed_grade Limitation:** The displayed_grade only works when a local database is provided. I haven't found an elegant way to retrieve this information from the API without significant performance issues. One potential solution is to integrate results from get_climb_stats and use the most logged or median difficulty.
- **Testing Scope:** The feature has only been tested with my own data from Grasshopper and Tension boards. More extensive testing might be needed to ensure robustness.
- **Backward Compatibility:** There might be issues with how tries were saved in older versions where the mechanics for "tries" were different. My database doesn't include such sends, making it difficult to test scenarios where the lookup returns something like "3 months".
- **Code Quality:** The code is not very elegant at this point and could benefit from further refactoring and cleanup.

### Recommendations

To balance functionality and performance, I propose maintaining two separate functions:

- Basic Logbook: For general use without a requirement for a local database.

- Detailed Logbook: For more in-depth analysis, requiring a local database to avoid performance issues.

Currently, the full logbook returns NA for displayed_grade when no local database is available, resulting in slow performance. Using a local database improves speed significantly.
### Conclusion

If these features align with your goals for the project, I am happy to refine the code based on your feedback and suggestions. Thank you for the opportunity to contribute. I look forward to building visualizations with this data.