### PR TITLE
Aggregated Logbook 

### DIFF
--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -1,17 +1,16 @@
 import argparse
 import csv
-import getpass
 import os
 import pathlib
 import sys
-
+import pandas as pd
+import getpass
 import boardlib.api.aurora
 import boardlib.api.moon
 import boardlib.db.aurora
 
 
-LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "difficulty", "tries", "is_mirror", "sessions_count", "tries_total", "is_repeat", "is_ascent", "comment")
-
+LOGBOOK_FIELDS = ("board", "angle", "climb_name", "date", "logged_grade", "displayed_grade", "difficulty", "tries", "is_mirror", "is_ascent", "comment", "sessions_count", "tries_total", "is_repeat")
 
 def logbook_entries(board, username, password, grade_type="font", database=None):
     api = (
@@ -20,14 +19,14 @@ def logbook_entries(board, username, password, grade_type="font", database=None)
         else boardlib.api.aurora
         if board in boardlib.api.aurora.HOST_BASES
         else None
-    )
+    ) 
     if api:
-        yield from api.logbook_entries(board, username, password, grade_type, database)
-
+        entries = api.logbook_entries(board, username, password, grade_type, db_path=database, aggregate=False) 
+        for entry in entries:
+            if isinstance(entry, dict):
+                yield entry
     else:
         raise ValueError(f"Unknown board {board}")
-
-
 
 def write_entries(output_file, entries, no_headers=False, fields=LOGBOOK_FIELDS):
     writer = csv.DictWriter(output_file, fieldnames=fields)
@@ -35,26 +34,18 @@ def write_entries(output_file, entries, no_headers=False, fields=LOGBOOK_FIELDS)
         writer.writeheader()
     writer.writerows(entries)
 
-
 def handle_database_command(args):
     if not args.database_path.exists():
         args.database_path.parent.mkdir(parents=True, exist_ok=True)
-        print(f"Downloading database to {args.database_path}")
         boardlib.db.aurora.download_database(args.board, args.database_path)
-
-    print(f"Synchronizing database at {args.database_path}")
-    row_counts = boardlib.db.aurora.sync_shared_tables(args.board, args.database_path)
-    for table_name, row_count in row_counts.items():
-        print(f"Synchronized {row_count} rows in {table_name}")
-
+    boardlib.db.aurora.sync_shared_tables(args.board, args.database_path)
 
 def handle_logbook_command(args):
     env_var = f"{args.board.upper()}_PASSWORD"
     password = os.environ.get(env_var)
     if not password:
         password = getpass.getpass("Password: ")
-    entries = boardlib.api.aurora.logbook_entries(args.board, args.username, password, args.grade_type, args.database)
-
+    entries = boardlib.api.aurora.logbook_entries(args.board, args.username, password, args.grade_type, db_path=args.database)
     if args.output:
         with open(args.output, "w", encoding="utf-8") as output_file:
             write_entries(output_file, entries.to_dict(orient="records"), args.no_headers, fields=LOGBOOK_FIELDS)
@@ -62,61 +53,21 @@ def handle_logbook_command(args):
         sys.stdout.reconfigure(encoding="utf-8")
         write_entries(sys.stdout, entries.to_dict(orient="records"), args.no_headers, fields=LOGBOOK_FIELDS)
 
-
 def add_database_parser(subparsers):
-    database_parser = subparsers.add_parser(
-        "database", help="Download and sync the database"
-    )
-    database_parser.add_argument(
-        "board",
-        help="Board name",
-        choices=sorted(boardlib.api.aurora.HOST_BASES.keys()),
-    )
-    database_parser.add_argument(
-        "database_path",
-        help=(
-            "Path for the database file. "
-            "If the file does not exist, the database will be downloaded to the given path and synchronized. "
-            "If it does exist, the database will just be synchronized",
-        ),
-        type=pathlib.Path,
-    )
+    database_parser = subparsers.add_parser("database", help="Download and sync the database")
+    database_parser.add_argument("board", help="Board name", choices=sorted(boardlib.api.aurora.HOST_BASES.keys()))
+    database_parser.add_argument("database_path", help="Path for the database file.", type=pathlib.Path)
     database_parser.set_defaults(func=handle_database_command)
 
-    
 def add_logbook_parser(subparsers):
-    logbook_parser = subparsers.add_parser(
-        "logbook", help="Download full logbook entries (ascents and bids) to CSV"
-    )
-    logbook_parser.add_argument(
-        "board",
-        help="Board name",
-        choices=sorted(
-            boardlib.api.moon.BOARD_IDS.keys() | boardlib.api.aurora.HOST_BASES.keys()
-        ),
-    )
+    logbook_parser = subparsers.add_parser("logbook", help="Download full logbook entries (ascents and bids) to CSV")
+    logbook_parser.add_argument("board", help="Board name", choices=sorted(boardlib.api.moon.BOARD_IDS.keys() | boardlib.api.aurora.HOST_BASES.keys()))
     logbook_parser.add_argument("-u", "--username", help="Username", required=True)
     logbook_parser.add_argument("-o", "--output", help="Output file", required=False)
-    logbook_parser.add_argument(
-        "--no-headers", help="Don't write headers", action="store_true", required=False
-    )
-    logbook_parser.add_argument(
-        "-g",
-        "--grade-type",
-        help="Grade type",
-        choices=("font", "hueco"),
-        default="font",
-        required=False,
-    )
-    logbook_parser.add_argument(
-        "-d",
-        "--database",
-        help="Path to the local database (optional). Using a local database will significantly speed up the logbook generation and is required to retrieve 'displayed_grade' and 'difficulty'. Create a local database with the 'database' command.",
-        type=pathlib.Path,
-        required=False,
-    )
+    logbook_parser.add_argument("--no-headers", help="Don't write headers", action="store_true", required=False)
+    logbook_parser.add_argument("-g", "--grade-type", help="Grade type", choices=("font", "hueco"), default="font", required=False)
+    logbook_parser.add_argument("-d", "--database", help="Path to the local database (optional).", type=pathlib.Path, required=False)
     logbook_parser.set_defaults(func=handle_logbook_command)
-    
 
 def main():
     parser = argparse.ArgumentParser()
@@ -125,8 +76,6 @@ def main():
     add_database_parser(subparsers)
     args = parser.parse_args()
     args.func(args)
-
-
 
 if __name__ == "__main__":
     main()

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -378,7 +378,7 @@ def bids_logbook_entries(board, username, password, db_path=None):
             climb_name = get_climb_name_from_db(db_path, raw_entry["climb_uuid"])
         else:
             climb_name = get_climb_name(board, raw_entry["climb_uuid"])
-
+        
         yield {
             "uuid": raw_entry["uuid"],
             "user_id": raw_entry["user_id"],
@@ -425,9 +425,9 @@ def process_raw_ascent_entries(raw_ascents_entries, board, db_path, grades_dict,
             climb_name = get_climb_name(board, raw_entry["climb_uuid"])
             difficulty = None
             displayed_grade = None
-
+        
         logged_grade = convert_difficulty_to_grade(raw_entry["difficulty"], grades_dict, grade_type)
-
+        
         ascents_entries.append({
             "board": board,
             "angle": raw_entry["angle"],
@@ -559,7 +559,7 @@ def logbook_entries(board, username, password, grade_type="font", db_path=None):
         bids_summary = summarize_bids(bids_df, board)
     else:
         bids_summary = pd.DataFrame(columns=['climb_uuid', 'climb_name', 'date', 'is_mirror', 'angle', 'tries', 'board'])
-
+    
     if raw_ascents_entries:
         grades = get_grades(board)
         grades_dict = {grade['difficulty']: grade for grade in grades}
@@ -569,10 +569,10 @@ def logbook_entries(board, username, password, grade_type="font", db_path=None):
         ascents_df = pd.DataFrame(columns=['board', 'angle', 'climb_uuid', 'name', 'date', 'logged_grade', 'difficulty', 'displayed_grade', 'tries', 'is_mirror', 'comment'])
 
     final_logbook = combine_ascents_and_bids(ascents_df, bids_summary, db_path, grades_dict, grade_type)
-
+    
     full_logbook_df = pd.DataFrame(final_logbook, columns=['board', 'angle', 'climb_name', 'date', 'logged_grade', 'displayed_grade', 'difficulty', 'tries', 'is_mirror', 'is_ascent', 'comment'])
     full_logbook_df['date'] = pd.to_datetime(full_logbook_df['date'])
-
+    
     full_logbook_df = full_logbook_df.groupby(['climb_name', 'is_mirror', 'angle']).apply(calculate_sessions_count).reset_index(drop=True)
     full_logbook_df = full_logbook_df.groupby(['climb_name', 'is_mirror', 'angle']).apply(calculate_tries_total).reset_index(drop=True)
     

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -575,7 +575,7 @@ def logbook_entries(board, username, password, grade_type="font", db_path=None):
 
     full_logbook_df = full_logbook_df.groupby(['climb_name', 'is_mirror', 'angle']).apply(calculate_sessions_count).reset_index(drop=True)
     full_logbook_df = full_logbook_df.groupby(['climb_name', 'is_mirror', 'angle']).apply(calculate_tries_total).reset_index(drop=True)
-
+    
     full_logbook_df['is_repeat'] = full_logbook_df.duplicated(subset=['climb_name', 'is_mirror', 'angle'], keep='first')
     full_logbook_df = full_logbook_df.sort_values(by='date')
 

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -613,7 +613,6 @@ def days_to_years_months_days(days):
     if delta.months > 0:
         parts.append(f"{delta.months} month{'s' if delta.months > 1 else ''}")
     parts.append(f"{delta.days} day{'s' if delta.days > 1 else ''}")
-
     return ' and '.join(parts)
 
 def combine_ascents_and_bids_agg(ascents_df, bids_summary):
@@ -657,7 +656,6 @@ def combine_ascents_and_bids_agg(ascents_df, bids_summary):
             'date': bid_row['date'],
             'tries': bid_row['tries']
         })
-
     return final_logbook
 
 def logbook_entries_agg(board, token, user_id, db_path=None, grade_type="font"):
@@ -694,5 +692,4 @@ def logbook_entries_agg(board, token, user_id, db_path=None, grade_type="font"):
     current_date = dt.now()
     aggregated_logbook['days'] = aggregated_logbook['date'].apply(lambda x: (current_date - pd.to_datetime(x)).days)
     aggregated_logbook['time_since'] = aggregated_logbook['days'].apply(days_to_years_months_days)
-
     return aggregated_logbook

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -372,7 +372,7 @@ def get_bids_logbook(board, token, user_id):
 def bids_logbook_entries(board, username, password, db_path=None):
     login_info = login(board, username, password)
     raw_entries = get_bids_logbook(board, login_info["token"], login_info["user_id"])
-
+    
     for raw_entry in raw_entries:
         if db_path:
             climb_name = get_climb_name_from_db(db_path, raw_entry["climb_uuid"])
@@ -397,7 +397,7 @@ def get_difficulty_from_db(database, climb_uuid, angle):
     conn = sqlite3.connect(database)
     cursor = conn.cursor()
     cursor.execute(
-        "SELECT display_difficulty FROM climb_stats WHERE climb_uuid = ? AND angle = ?",
+        "SELECT display_difficulty FROM climb_stats WHERE climb_uuid = ? AND angle = ?", 
         (climb_uuid, angle)
     )
     row = cursor.fetchone()
@@ -439,7 +439,7 @@ def process_raw_ascent_entries(raw_ascents_entries, board, db_path, grades_dict,
             "displayed_grade": displayed_grade,
             "tries": raw_entry["attempt_id"] if raw_entry["attempt_id"] else raw_entry["bid_count"],
             "is_mirror": raw_entry["is_mirror"],
-            "comment": raw_entry["comment"]
+            "comment": raw_entry["comment"] 
         })
     return ascents_entries
 
@@ -463,14 +463,14 @@ def combine_ascents_and_bids(ascents_df, bids_summary, db_path, grades_dict, gra
         ascent_climb_name = ascent_row['name']
         ascent_is_mirror = ascent_row['is_mirror']
         ascent_angle = ascent_row['angle']
-
+        
         bid_match = bids_summary[
-            (bids_summary['climb_uuid'] == ascent_climb_uuid) &
-            (bids_summary['date'] == ascent_date) &
+            (bids_summary['climb_uuid'] == ascent_climb_uuid) & 
+            (bids_summary['date'] == ascent_date) & 
             (bids_summary['is_mirror'] == ascent_is_mirror) &
             (bids_summary['angle'] == ascent_angle)
         ]
-
+        
         if not bid_match.empty:
             bid_row = bid_match.iloc[0]
             total_tries = ascent_row['tries'] + bid_row['tries']
@@ -510,7 +510,7 @@ def combine_ascents_and_bids(ascents_df, bids_summary, db_path, grades_dict, gra
         else:
             displayed_grade = None
             difficulty = None
-
+        
         final_logbook.append({
             'board': bid_row['board'],
             'angle': bid_row['angle'],
@@ -546,10 +546,10 @@ def logbook_entries(board, username, password, grade_type="font", db_path=None):
     login_info = login(board, username, password)
     token = login_info["token"]
     user_id = login_info["user_id"]
-
+    
     bids_entries = list(bids_logbook_entries(board, username, password, db_path))
     raw_ascents_entries = get_logbook(board, token, user_id)
-
+    
     if not bids_entries and not raw_ascents_entries:
         return pd.DataFrame(columns=['board', 'angle', 'climb_name', 'date', 'logged_grade', 'displayed_grade', 'difficulty', 'tries', 'is_mirror', 'is_ascent', 'comment'])
 
@@ -578,7 +578,7 @@ def logbook_entries(board, username, password, grade_type="font", db_path=None):
     
     full_logbook_df['is_repeat'] = full_logbook_df.duplicated(subset=['climb_name', 'is_mirror', 'angle'], keep='first')
     full_logbook_df = full_logbook_df.sort_values(by='date')
-
+    
     return full_logbook_df
 
 def bids_logbook_entries_agg(board, token, user_id, db_path=None):


### PR DESCRIPTION
as discussed in https://github.com/lemeryfertitta/Climbdex/issues/55

slightly updated version of `logbook_entries()` functions from @PTschaikner to create an aggregated logbook `logbook_entries_agg()` with all needed informations which are used to get personal stats about the each climb ('climb_uuid', 'climb_name', 'board', 'date', 'is_mirror', 'angle', 'tries', 'sessions' 'time_since').

instead of the login credentials (user_id and password) `logbook_entries_agg()` uses user_id and token to fetch the results. 