### PR TITLE
Document user_syncs better

### DIFF
--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -181,6 +181,7 @@ def user_sync(
     :parm shared_syncs: list of {"table_name": <table_name>, "last_synchronized_at": <last_synchronized_at>}
         e.g. [{'table_name': 'climbs', 'last_synchronized_at': '2023-06-07 20:36:41.578003'}]
         It looks like the largest table (climbs) won't synchronize unless it has a shared_sync with last_synchronized_at set.
+    :parm user_syncs: Similiar to shared_syncs but for the user tables, also requires the user_id for each array item
     """
     response = requests.post(
         f"{API_HOSTS[board]}/v1/sync",


### PR DESCRIPTION
I was trying to figure out how to get user sync to actually use the last_synchronized_at, turned out I had to also pass the user_id