### PR TITLE
fix moonboard login

### DIFF
--- a/src/boardlib/api/moon.py
+++ b/src/boardlib/api/moon.py
@@ -52,7 +52,9 @@ IDS_TO_ANGLES = {
 
 def get_session(username, password):
     session = requests.Session()
-    
+    session.headers.update({
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+})
     login_page = session.get(f"{HOST}/account/login")
     login_page.raise_for_status()
     


### PR DESCRIPTION
### Problem: 
Moonboard server does not respond to https request "Remote end closed connection without response". Refer Issue #75. 

### Proposed solution: 
add generic User-Agent of a browser instead of the default User-Agent. In https request the following change will be visible in header: 
old: User-Agent = python-requests/3.x.x
new: User-Agent = Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36

### Testing: 
tested with my own user after compiling the project locally:

  1. python -m build --no-isolation
  2.  pip install C:\test\dist\boardlib-0.14.1-py3-none-any.whl --config-setting="--build-option=--debug" --force-reinstall
  3. boardlib logbook moon2019 --username="_placeholder_" --output="1.csv"

Before Fix: empty csv generated with error message mentioned in Issue #75 
After Fix: csv is populated with my sessions on MB2019 setup, no error messages 