### PR TITLE
download-all command and overlayed layout images in download_images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 tmp
 dist
 __pycache__/
+data_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4
 requests
 pandas
+PIL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4
 requests
-pandas
-PIL
+Pillow

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -27,6 +27,16 @@ LOGBOOK_FIELDS = (
     "comment",
 )
 
+AURORA_DATABASES = (
+    "aurora",
+    "decoy",
+    "grasshopper",
+    "kilter",
+    "soill",
+    "tension",
+    "touchstone",
+)
+
 
 def logbook_entries(board, username, password, database=None):
     api = (
@@ -130,6 +140,65 @@ def handle_logbook_command(args):
         )
 
 
+def handle_download_all_command(args):
+    output_dir = args.output_directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading all Aurora databases and images to {output_dir}")
+
+    boards = AURORA_DATABASES
+    if args.boards:
+        boards = tuple(args.boards)
+
+    for board in boards:
+        db_path = output_dir / f"{board}.db"
+
+        # Download / sync the database
+        if not db_path.exists():
+            print(f"\n[{board}] Downloading database to {db_path}")
+            boardlib.db.aurora.download_database(board, db_path)
+        else:
+            print(f"\n[{board}] Database already exists at {db_path}, skipping download")
+
+        if args.username:
+            print(f"[{board}] Synchronizing database at {db_path}")
+            try:
+                token = get_aurora_login_token(board, args.username)
+                tables_and_sync_dates = boardlib.db.aurora.get_shared_syncs(db_path)
+                row_counts_totals = {}
+                for sync_result in boardlib.api.aurora.sync(
+                    board,
+                    tables_and_sync_dates,
+                    token=token,
+                    max_pages=args.max_sync_pages,
+                ):
+                    row_counts = boardlib.db.aurora.sync_shared_tables(
+                        db_path, sync_result
+                    )
+                    for table_name, row_count in row_counts.items():
+                        row_counts_totals[table_name] = (
+                            row_counts_totals.get(table_name, 0) + row_count
+                        )
+                        print(
+                            f"[{board}] Synchronized page of {table_name}. "
+                            f"Page size: {row_count}. Cumulative: {row_counts_totals[table_name]}"
+                        )
+            except Exception as e:
+                print(f"[{board}] Warning: sync failed: {e}")
+
+        # Download images
+        if not args.skip_images:
+            images_dir = output_dir / f"{board}-images"
+            images_dir.mkdir(parents=True, exist_ok=True)
+            print(f"[{board}] Downloading images to {images_dir}")
+            try:
+                boardlib.api.aurora.download_images(board, db_path, images_dir)
+                print(f"[{board}] Images downloaded successfully")
+            except Exception as e:
+                print(f"[{board}] Warning: image download failed: {e}")
+
+    print("\nDone.")
+
+
 def handle_images_command(args):
     print(f"Downloading images for {args.board} to {args.output_directory}")
     boardlib.api.aurora.download_images(args.board, args.database_path, args.output_directory)
@@ -216,12 +285,51 @@ def add_images_parser(subparsers):
     images_parser.set_defaults(func=handle_images_command)
 
 
+def add_download_all_parser(subparsers):
+    download_all_parser = subparsers.add_parser(
+        "download-all",
+        help="Download all Aurora databases and images into a single directory",
+    )
+    download_all_parser.add_argument(
+        "output_directory",
+        help="Directory to store all databases and image folders",
+        type=pathlib.Path,
+    )
+    download_all_parser.add_argument(
+        "-u", "--username",
+        help="Username. If provided, databases will be synchronized after download",
+        required=False,
+    )
+    download_all_parser.add_argument(
+        "-b", "--boards",
+        help="Specific boards to download (default: all Aurora databases)",
+        nargs="+",
+        choices=sorted(boardlib.api.aurora.HOST_BASES.keys()),
+        required=False,
+    )
+    download_all_parser.add_argument(
+        "-m",
+        "--max-sync-pages",
+        help="Maximum number of times to call the sync API per board. Defaults to 100.",
+        type=int,
+        default=boardlib.api.aurora.DEFAULT_MAX_SYNC_PAGES,
+    )
+    download_all_parser.add_argument(
+        "--skip-images",
+        help="Skip downloading images",
+        action="store_true",
+        required=False,
+    )
+    download_all_parser.set_defaults(func=handle_download_all_command)
+
+
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     add_logbook_parser(subparsers)
     add_database_parser(subparsers)
     add_images_parser(subparsers)
+    add_download_all_parser(subparsers)
     args = parser.parse_args()
     args.func(args)
 

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -182,7 +182,7 @@ def handle_download_all_command(args):
             images_dir.mkdir(parents=True, exist_ok=True)
             print(f"[{board}] Downloading images to {images_dir}")
             try:
-                boardlib.api.aurora.download_images(board, db_path, images_dir)
+                boardlib.api.aurora.download_images(board, db_path, images_dir, args.composite)
                 print(f"[{board}] Images downloaded successfully")
             except Exception as e:
                 print(f"[{board}] Warning: image download failed: {e}")
@@ -192,7 +192,7 @@ def handle_download_all_command(args):
 
 def handle_images_command(args):
     print(f"Downloading images for {args.board} to {args.output_directory}")
-    boardlib.api.aurora.download_images(args.board, args.database_path, args.output_directory, args.raw)
+    boardlib.api.aurora.download_images(args.board, args.database_path, args.output_directory, args.composite)
     print("Images downloaded successfully")
 
 
@@ -315,6 +315,12 @@ def add_download_all_parser(subparsers):
         "--skip-images",
         help="Skip downloading images",
         action="store_true",
+        required=False,
+    )
+    download_all_parser.add_argument(
+        "--composite",
+        action="store_true",
+        help="Build composite layout images for each board layout.",
         required=False,
     )
     download_all_parser.set_defaults(func=handle_download_all_command)

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -201,7 +201,7 @@ def handle_download_all_command(args):
 
 def handle_images_command(args):
     print(f"Downloading images for {args.board} to {args.output_directory}")
-    boardlib.api.aurora.download_images(args.board, args.database_path, args.output_directory)
+    boardlib.api.aurora.download_images(args.board, args.database_path, args.output_directory, args.raw)
     print("Images downloaded successfully")
 
 
@@ -281,6 +281,12 @@ def add_images_parser(subparsers):
         "output_directory",
         help="Directory to save the downloaded images",
         type=pathlib.Path,
+    )
+    images_parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Just download the raw images. Don't build full layout images.",
+        required = False
     )
     images_parser.set_defaults(func=handle_images_command)
 

--- a/src/boardlib/__main__.py
+++ b/src/boardlib/__main__.py
@@ -27,16 +27,6 @@ LOGBOOK_FIELDS = (
     "comment",
 )
 
-AURORA_DATABASES = (
-    "aurora",
-    "decoy",
-    "grasshopper",
-    "kilter",
-    "soill",
-    "tension",
-    "touchstone",
-)
-
 
 def logbook_entries(board, username, password, database=None):
     api = (
@@ -67,6 +57,7 @@ def get_password(board):
     if not password:
         password = getpass.getpass("Password: ")
     return password
+
 
 def get_aurora_login_token(board, username):
     password = get_password(board)
@@ -145,7 +136,7 @@ def handle_download_all_command(args):
     output_dir.mkdir(parents=True, exist_ok=True)
     print(f"Downloading all Aurora databases and images to {output_dir}")
 
-    boards = AURORA_DATABASES
+    boards = tuple(boardlib.api.aurora.HOST_BASES.keys())
     if args.boards:
         boards = tuple(args.boards)
 
@@ -283,9 +274,9 @@ def add_images_parser(subparsers):
         type=pathlib.Path,
     )
     images_parser.add_argument(
-        "--raw",
+        "--composite",
         action="store_true",
-        help="Just download the raw images. Don't build full layout images.",
+        help="Build composite layout images for each board layout.",
         required = False
     )
     images_parser.set_defaults(func=handle_images_command)

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -176,8 +176,8 @@ def download_images(board, database_path, output_directory, composite=False):
     :param board: The board name
     :param database_path: Path to the SQLite database file
     :param output_directory: Directory to save the downloaded images
-    :param composite: Optionally build full composite layout images from hold sets.
-    """    
+    :param composite: If true, build composite layout images for each board layout
+    """
     os.makedirs(output_directory, exist_ok=True)
     image_filenames = boardlib.db.aurora.get_image_filenames(database_path)
     api_host = f"https://api.{HOST_BASES[board]}.com"

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -6,6 +6,8 @@ import requests
 import pandas as pd
 
 import boardlib.db.aurora
+import boardlib.util.images
+
 
 BASE_SYNC_DATE = "1970-01-01 00:00:00.000000"
 DEFAULT_MAX_SYNC_PAGES = 100
@@ -167,7 +169,7 @@ def gym_boards(board):
         }
 
 
-def download_images(board, database_path, output_directory):
+def download_images(board, database_path, output_directory, full_layout_images=True):
     """
     Download all images for a given board to the specified directory.
     
@@ -197,6 +199,14 @@ def download_images(board, database_path, output_directory):
         with open(output_path, "wb") as output_file:
             output_file.write(response.content)
 
+    if (full_layout_images):
+        # Get the layouts-image-path dict from the database
+        layouts_images_dict = boardlib.db.aurora.get_layouts_images_dict(database_path)
+
+        # Construct the images one at a time.
+        for (layout, product_size), image_names in layouts_images_dict.items():
+            image_path = os.path.join(output_directory, layout, f"{product_size}.png")
+            boardlib.util.images.overlay_images(output_directory, image_names, image_path)
 
 def generate_uuid():
     return str(uuid.uuid4()).replace("-", "")

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -169,13 +169,14 @@ def gym_boards(board):
         }
 
 
-def download_images(board, database_path, output_directory, raw=False):
+def download_images(board, database_path, output_directory, composite=False):
     """
     Download all images for a given board to the specified directory.
     
     :param board: The board name
     :param database_path: Path to the SQLite database file
     :param output_directory: Directory to save the downloaded images
+    :param composite: Optionally build full composite layout images from hold sets.
     """    
     os.makedirs(output_directory, exist_ok=True)
     image_filenames = boardlib.db.aurora.get_image_filenames(database_path)
@@ -199,16 +200,14 @@ def download_images(board, database_path, output_directory, raw=False):
         with open(output_path, "wb") as output_file:
             output_file.write(response.content)
 
-    if (raw):
-        return
-    
-    # Get the layouts-image-path dict from the database
-    layouts_images_dict = boardlib.db.aurora.get_layouts_images_dict(database_path)
-    
-    # Construct the images one at a time.
-    for (layout, product_size), image_names in layouts_images_dict.items():
-        image_path = os.path.join(output_directory, layout, f"{product_size}.png")
-        boardlib.util.images.overlay_images(output_directory, image_names, image_path)
+    if (composite):  
+        # Get the layouts-image-path dict from the database
+        layouts_images_dict = boardlib.db.aurora.get_layouts_images_dict(database_path)
+        
+        # Construct the images one at a time.
+        for (layout, product_size), image_names in layouts_images_dict.items():
+            image_path = os.path.join(output_directory, layout, f"{product_size}.png")
+            boardlib.util.images.overlay_images(output_directory, image_names, image_path)
 
 def generate_uuid():
     return str(uuid.uuid4()).replace("-", "")

--- a/src/boardlib/api/aurora.py
+++ b/src/boardlib/api/aurora.py
@@ -169,7 +169,7 @@ def gym_boards(board):
         }
 
 
-def download_images(board, database_path, output_directory, full_layout_images=True):
+def download_images(board, database_path, output_directory, raw=False):
     """
     Download all images for a given board to the specified directory.
     
@@ -199,14 +199,16 @@ def download_images(board, database_path, output_directory, full_layout_images=T
         with open(output_path, "wb") as output_file:
             output_file.write(response.content)
 
-    if (full_layout_images):
-        # Get the layouts-image-path dict from the database
-        layouts_images_dict = boardlib.db.aurora.get_layouts_images_dict(database_path)
-
-        # Construct the images one at a time.
-        for (layout, product_size), image_names in layouts_images_dict.items():
-            image_path = os.path.join(output_directory, layout, f"{product_size}.png")
-            boardlib.util.images.overlay_images(output_directory, image_names, image_path)
+    if (raw):
+        return
+    
+    # Get the layouts-image-path dict from the database
+    layouts_images_dict = boardlib.db.aurora.get_layouts_images_dict(database_path)
+    
+    # Construct the images one at a time.
+    for (layout, product_size), image_names in layouts_images_dict.items():
+        image_path = os.path.join(output_directory, layout, f"{product_size}.png")
+        boardlib.util.images.overlay_images(output_directory, image_names, image_path)
 
 def generate_uuid():
     return str(uuid.uuid4()).replace("-", "")

--- a/src/boardlib/db/aurora.py
+++ b/src/boardlib/db/aurora.py
@@ -169,7 +169,30 @@ def get_climb_name(database, climb_uuid):
 
 def get_image_filenames(database):
     with sqlite3.connect(database) as connection:
-        results = connection.execute(
-            "SELECT image_filename FROM product_sizes_layouts_sets WHERE image_filename IS NOT NULL"
+        results = results = connection.execute(
+            """
+            SELECT image_filename FROM product_sizes_layouts_sets WHERE image_filename IS NOT NULL
+            """
         )
         return [row[0] for row in results]
+
+def get_layouts_images_dict(database):
+    with sqlite3.connect(database) as connection:
+        results = connection.execute(
+            """
+            SELECT
+                l.name layout_name,
+                s.name product_size_name,
+                p.image_filename
+            FROM product_sizes_layouts_sets p
+            INNER JOIN 
+                (SELECT id, name FROM layouts) AS l ON p.layout_id = l.id
+            INNER JOIN
+                (SELECT id, name FROM product_sizes) AS s ON p.product_size_id = s.id;
+            """
+        )
+
+        layouts_images_dict = collections.defaultdict(list)
+        for row in results:
+            layouts_images_dict[(row[0],row[1])].append(row[2])
+        return layouts_images_dict

--- a/src/boardlib/db/aurora.py
+++ b/src/boardlib/db/aurora.py
@@ -169,11 +169,7 @@ def get_climb_name(database, climb_uuid):
 
 def get_image_filenames(database):
     with sqlite3.connect(database) as connection:
-        results = results = connection.execute(
-            """
-            SELECT image_filename FROM product_sizes_layouts_sets WHERE image_filename IS NOT NULL
-            """
-        )
+        results = connection.execute("SELECT image_filename FROM product_sizes_layouts_sets WHERE image_filename IS NOT NULL")
         return [row[0] for row in results]
 
 def get_layouts_images_dict(database):

--- a/src/boardlib/util/images.py
+++ b/src/boardlib/util/images.py
@@ -1,0 +1,24 @@
+import os
+from PIL import Image
+
+def overlay_images(base_dir, image_paths, output_filepath):
+    """
+    Creates an overlayed image of an entire board layout from the various hold-set images.
+    Assumes that all input images are from the same layout+product_size and are thus compatible for a raw overlay.
+    
+    :param base_dir: The base directory.
+    :param image_paths: The list of image paths for each layout image.
+    :param output_filepath: The final filepath to which to save the overlayed images.
+    """    
+    images = [Image.open(f"{base_dir}/{image_path}").convert("RGBA") for image_path in image_paths]
+
+    canvas = Image.new("RGBA", (images[0].width, images[0].height), (0, 0, 0, 0))
+
+    for img in images:
+        canvas.paste(img, mask=img)
+
+    output_dir = os.path.dirname(output_filepath)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    canvas.save(output_filepath, "PNG")


### PR DESCRIPTION
1-"download-all" command automatically downloads all aurora databases and images into a single directory.
This directory contains a DB file and an image directory for each Aurora board:
<img width="745" height="401" alt="image" src="https://github.com/user-attachments/assets/7bd0c3b2-cfe5-47db-ab81-f2b245b8eff8" />

2-"images" command now creates full layout images by overlaying the various layout sets images.
These layout images are organized as:
    <image_directory> / <layout_name> / <product_size_name>.PNG
<img width="609" height="313" alt="image" src="https://github.com/user-attachments/assets/036a6fd4-5d06-42b8-b976-61aba27412a2" />

An example board (TB2 Spray 12x12):
<img width="1080" height="1144" alt="12 high x 12 wide" src="https://github.com/user-attachments/assets/b2d38e9b-db7f-4453-acf4-805ea4e8c5f4" />
